### PR TITLE
Update maps.php

### DIFF
--- a/maps.php
+++ b/maps.php
@@ -22,6 +22,13 @@
 </head>
 
 <body>
+    <!-- Redirect User to HTTPS site -->
+    
+     if (location.protocol !== "https:"){
+      //redirect to https traffic when loaded with http
+     location.replace(window.location.href.replace("http:", "https:"));
+    }
+    
     <!--To prevent user from using Ctrl shortcuts-->
 <!--<body oncontextmenu="return false" onkeydown="return false;" onmousedown="return false;" >
     <?php


### PR DESCRIPTION
Mobile devices do not accept the leak of location data on an unencrypted channel therefore the page should be served over https channel only thus I have added a script that will redirect to a secure site. 
For this to work you must have added self-signed certificates to your site or used lets-encrypt certificates on a production system.
On making this change - mobile devices show a popup of querying current device's location.

Signed-off-by: Cheserem Titus <50730372+cheseremtitus24@users.noreply.github.com>